### PR TITLE
VORC, VRX and VCS

### DIFF
--- a/repos/repos.yaml
+++ b/repos/repos.yaml
@@ -14,7 +14,7 @@ repositories:
   vrx:
     type: git
     url: git@github.com:osrf/vrx.git
-    version: master
+    version: vorc-dev
   geonav_transform:
     type: git
     url: git@github.com:bsb808/geonav_transform.git


### PR DESCRIPTION
With the merging of VORC with VRX (see PR - https://github.com/osrf/vrx/pull/470)  the build instructions (see https://github.com/Field-Robotics-Lab/optical_swarm/wiki/workspace_setup) break.  I made a branch of VRX that continues to be compatible with VORC and then update the VCS repos list points to a branch of VRX known to work with the dedicated (non-master) branch.